### PR TITLE
Remove mighty.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Contributing: I gladly accept additions to the lists below; please submit an iss
 * [Kili](https://kili-technology.com/)
 * [Labelbox](https://www.labelbox.com/)
 * [LinkedAI](https://linkedai.co/)
-* [Mighty AI](https://mighty.ai/)
 * [Oclavi](https://oclavi.com/)
 * [Prodigy](https://prodi.gy/) -- image classification
 * [RectLabel](https://rectlabel.com/) -- classification, bounding box, polygon, cubic bezier


### PR DESCRIPTION
Uber acquired mighty.ai. It is not available to the public since 2019.