### PR TITLE
added Grid-Annotation-Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Contributing: I gladly accept additions to the lists below; please submit an iss
 * [VATIC](http://www.cs.columbia.edu/~vondrick/vatic/), [VATIC.js](https://github.com/dbolkensteyn/vatic.js) -- video tracking
 * [VGG Image Annotator (VIA)](http://www.robots.ox.ac.uk/~vgg/software/via/) -- image (polygons, geometric shapes)
 * [ViPER-GT](http://viper-toolkit.sourceforge.net/products/gt/) -- video (classification, temporal segmentation, tracking)
+* [Grid-Annotation-Tool](https://github.com/LukasBommes/Grid-Annotation-Tool) -- image (rectangle grids)
 
 ### Commercial
 * [Amazon Sagemaker Ground Truth](https://aws.amazon.com/sagemaker/groundtruth/)


### PR DESCRIPTION
I added Grid-Annotation-Tool, which specializes on annotation of rectangular grids in images. It allows for faster and cleaner annotation of instance segmentation masks in case the scene is a regular grid. It was originally developed to annotate instance segmentation masks for photovoltaic modules in low-altitude aerial imagery, but other applications are of course possible.