### PR TITLE
Add factgenie

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Contributing: I gladly accept additions to the lists below; please submit an iss
 * [DataQA](https://github.com/dataqa/dataqa) - classification, NER, NEL
 * [DAML](https://github.com/vmware/data-annotator-for-machine-learning) -- Data Annotator for Machine Learning (DAML) -- text classification, NER, tabular classification and regression, image (bounding box, polygon), log labelling
 * [doccano](https://github.com/chakki-works/doccano) -- NER, sentiment, translation
-* [factgenie](https://github.com/kasnerz/factgenie) -- span-level annotations, focused on LLM hallucinations
+* [factgenie](https://github.com/kasnerz/factgenie) -- token-level annotations from crowdworkers and LLMs
 * [FoLiA Linguisitc Annotation Tool (Flat)](https://github.com/proycon/flat)
 * [Hover](https://github.com/phurwicz/hover)
 * [Label Studio](https://github.com/heartexlabs/label-studio) -- image, audio, text

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Contributing: I gladly accept additions to the lists below; please submit an iss
 * [DataQA](https://github.com/dataqa/dataqa) - classification, NER, NEL
 * [DAML](https://github.com/vmware/data-annotator-for-machine-learning) -- Data Annotator for Machine Learning (DAML) -- text classification, NER, tabular classification and regression, image (bounding box, polygon), log labelling
 * [doccano](https://github.com/chakki-works/doccano) -- NER, sentiment, translation
+* [factgenie](https://github.com/kasnerz/factgenie) -- span-level annotations, focused on LLM hallucinations
 * [FoLiA Linguisitc Annotation Tool (Flat)](https://github.com/proycon/flat)
 * [Hover](https://github.com/phurwicz/hover)
 * [Label Studio](https://github.com/heartexlabs/label-studio) -- image, audio, text


### PR DESCRIPTION
Add our open-source framework for token-level annotations of texts generated by LLMs.

The framework can elicit annotations both from human crowdworkers and LLM-based evaluators.